### PR TITLE
Modify reset button behavior

### DIFF
--- a/firmware-root/etc/rc.button/reset
+++ b/firmware-root/etc/rc.button/reset
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+OVERLAY="$( grep ' /overlay ' /proc/mounts )"
+
+case "$ACTION" in
+timeout)
+        . /etc/diag.sh
+        set_state failsafe
+;;
+released)
+        if [ "$SEEN" -lt 1 ]
+        then
+                echo "REBOOT" > /dev/console
+                sync
+                reboot
+        elif [ "$SEEN" -ge 5 -a -n "$OVERLAY" ]
+        then
+                echo "ROUTER RESET" > /dev/console
+                rm /overlay/upper/etc/config/wireless
+                /etc/init.d/rita stop
+                sed -i 's/rita_dashboard_password.*//g' /etc/rita.toml
+                sync
+                reboot
+        fi
+;;
+esac
+
+return 0


### PR DESCRIPTION
The default OpenWRT behavior for a long press of the reset button over 5 secs is to completely erase the changed files overlay on the squashfs filesystem.  This commit replaces that to only delete the rita dashboard password and to remove only the wifi config from the overlay directory.  It does not do anything regarding the SSH password.