### PR TITLE
Fix nanopi-r2s build config

### DIFF
--- a/config/nanopi-r2s
+++ b/config/nanopi-r2s
@@ -1,6 +1,6 @@
 CONFIG_TARGET_rockchip=y
 CONFIG_TARGET_rockchip_armv8=y
-CONFIG_TARGET_DEVICE_rockchip_armv8_DEVICE_friendlyarm_nanopi-r2s=y
+CONFIG_TARGET_rockchip_armv8_DEVICE_friendlyarm_nanopi-r2s=y
 CONFIG_PACKAGE_althea-babeld=y
 CONFIG_PACKAGE_althea-cron-jobs=y
 CONFIG_PACKAGE_althea-dash=y

--- a/profiles/devices/nanopi-r2s.yml
+++ b/profiles/devices/nanopi-r2s.yml
@@ -2,8 +2,7 @@ conf_to_build: nanopi-r2s
 device: "friendlyarm_nanopi-r2s"
 package_id: aarch64_generic
 image_paths:
-  - "rockchip/armv8/openwrt-rockchip-armv8-firefly_roc-rk3328-cc-squashfs-sysupgrade.img.gz"
-  - "rockchip/armv8/openwrt-rockchip-armv8-firefly_roc-rk3328-cc-ext4-sysupgrade.img.gz"
+  - "rockchip/armv8/openwrt-rockchip-armv8-friendlyarm_nanopi-r2s-squashfs-sysupgrade.img.gz"
 supported: true
 
 listen_interfaces:


### PR DESCRIPTION
This PR fixes a problem in the config line that has always been there, but seems to only have become a problem during openwrt builds recently.  The problem caused the build to switch to the default rockchip device instead of the intended device.  This PR also removes the ext4 build image which is not known to be used or desirable to have. 